### PR TITLE
Expose LIQ and PNGQuant parameters.

### DIFF
--- a/piliq/__metadata__.py
+++ b/piliq/__metadata__.py
@@ -26,7 +26,7 @@ SOFTWARE.
 
 __MAJOR = 0
 __MINOR = 0
-__REV   = 2
+__REV   = 3
 
 __version__ = '.'.join(map(str, [__MAJOR, __MINOR, __REV]))
 __author__ = 'cubicibo'


### PR DESCRIPTION
Exposes internal parameters to tune LIQ behaviour (which are also available on PNGQuant). Pushes version to v0.0.3

- Speed [1; 10]
- Quality [1; 100]
- Dithering [0.0, 1.0] 